### PR TITLE
Add sqlcmd from releases

### DIFF
--- a/sqlinstance/Dockerfile
+++ b/sqlinstance/Dockerfile
@@ -9,23 +9,7 @@ ARG IMAGE
 
 ###
 #
-#   first temp/builder image: build go-sqlcmd for ARM since
-#   it's currently not included in the SQL Edge image
-#
-###
-
-# start with the golang base image which will be discarded
-FROM golang as sqlcmdbuilder
-
-# clone the go-sqlcmd repo
-RUN git clone --depth 1 https://github.com/microsoft/go-sqlcmd
-
-# change directories and compile sqlcmd to /tmp/sqlcmd
-RUN cd go-sqlcmd && go build -o /tmp/sqlcmd ./cmd/sqlcmd
-
-###
-#
-#   second temp/builder image: add users, logins, databases, etc
+#   temp/builder image: add users, logins, databases, etc
 #
 ###
 
@@ -34,9 +18,6 @@ FROM $IMAGE as builder
 
 # designate the stocked sql server
 ARG PRIMARYSQL
-
-# copy sqlcmd from the golang builder image above
-COPY --from=sqlcmdbuilder /tmp /tmp
 
 # switch to root to a bunch of stuff that requires elevated privs
 USER root

--- a/sqlinstance/scripts/start-sql.sh
+++ b/sqlinstance/scripts/start-sql.sh
@@ -9,9 +9,11 @@ cp /tmp/mssql.conf /var/opt/mssql/mssql.conf
 # check for arm64 which does not support sqlcmd
 arch=$(lscpu | awk '/Architecture:/{print $2}')
 if [ "$arch" = "aarch64" ]; then
+    wget https://github.com/microsoft/go-sqlcmd/releases/download/v0.2.0/sqlcmd-v0.2.0-linux-arm64.tar.bz2
+    tar -xvf sqlcmd-v0.2.0-linux-arm64.tar.bz2
     mkdir /opt/mssql-tools /opt/mssql-tools/bin
-    cp /tmp/sqlcmd /opt/mssql-tools/bin
-    chmod +x /opt/mssql-tools/bin/sqlcmd
+    cp sqlcmd /opt/mssql-tools/bin
+    chmod +x /opt/mssql-tools/bin/sqlcmd   
 fi
 
 # startup, wait for it to finish starting


### PR DESCRIPTION
msft now includes arm in their releases, so no need to compile manually