### PR TITLE
Pointing Stack Overflow backup to less expensive source

### DIFF
--- a/samples/stackoverflow/third/configure.sh
+++ b/samples/stackoverflow/third/configure.sh
@@ -17,7 +17,7 @@ export SQLCMDUSER=sqladmin
 sqlcmd -d master -Q "EXEC sp_dropserver @@SERVERNAME"
 sqlcmd -S localhost -d master -Q "EXEC sp_addserver 'mssql3', local"
 
-wget https://downloads.brentozar.com/StackOverflow2010.7z
+wget http://stackoverflow.brentozar.com/StackOverflow2010.7z
 7z e StackOverflow2010.7z
 mv /tmp/Stack*mdf /var/opt/mssql/data/
 sqlcmd -S localhost -d master -i /tmp/attach-db.sql


### PR DESCRIPTION
Right now, the Stack Overflow database is being pulled from an S3 distribution that has caching turned on. If we're going to make this part of an automated project, I'd rather have a separate S3 distribution that I don't cache, and costs me less. (I pay each time folks download that database.) Thanks for understanding!