### PR TITLE
So we can download the Stack database

### DIFF
--- a/samples/stackoverflow/Dockerfile.third
+++ b/samples/stackoverflow/Dockerfile.third
@@ -43,11 +43,13 @@ RUN /bin/bash /tmp/start-sql.sh
 FROM dbatools/mssqlbase
 COPY --from=builder /var/opt/mssql /var/opt/mssql
 COPY --from=builder /opt/mssql-tools/bin /opt/mssql-tools/bin
+# COPY --from=builder /tmp /tmp
 
 # make a shared dir with the proper permissions
 USER root
 RUN mkdir /shared; chown mssql /shared
 RUN chown -R mssql /opt/
+# RUN chown -R mssql /tmp
 
 # run a rootless container
 USER mssql

--- a/samples/stackoverflow/third/configure.sh
+++ b/samples/stackoverflow/third/configure.sh
@@ -18,7 +18,8 @@ sqlcmd -d master -Q "EXEC sp_dropserver @@SERVERNAME"
 sqlcmd -S localhost -d master -Q "EXEC sp_addserver 'mssql3', local"
 
 # Source -> http://stackoverflow.brentozar.com/StackOverflow2010.7z
-wget -O StackOverflow2010.7z https://dbatools.io/stackdb
-7z e StackOverflow2010.7z
+
+wget -O StackOverflow2010.7z http://stackoverflow.brentozar.com/StackOverflow2010.7z 2>&1 | tee -a /tmp/wget_logfile.log
+7z e StackOverflow2010.7z > /tmp/7z_logfile.log
 mv /tmp/Stack*mdf /var/opt/mssql/data/
 sqlcmd -S localhost -d master -i /tmp/attach-db.sql


### PR DESCRIPTION
I tried to create the shorturl stackdb

https://github.com/dataplat/web/commit/3a1940ef8411a9c9705df900ec36ce730d19a062

but even with that it didnt work so I removed it

https://github.com/dataplat/web/commit/bcc7c6ae547f8c75430bb7f76d0f24ca78fe66d9

Added direct link and left the logging which I used to troubleshoot as I commented out the copy in the dockerfile  ;-)