### PR TITLE
Enable env var for auto creation of MSSQL_DB if var exists and db does not

### DIFF
--- a/sqlinstance/Dockerfile
+++ b/sqlinstance/Dockerfile
@@ -46,6 +46,7 @@ RUN /bin/bash /tmp/start-sql.sh
 FROM dbatools/mssqlbase
 COPY --from=builder /var/opt/mssql /var/opt/mssql
 COPY --from=builder /opt/mssql-tools/bin /opt/mssql-tools/bin
+COPY --from=builder /tmp/post-entrypoint.sh /opt/mssql/bin/post-entrypoint.sh
 
 # make a shared dir with the proper permissions
 USER root
@@ -53,8 +54,8 @@ RUN  mkdir /shared; chown mssql /shared
 
 # run a rootless container
 USER mssql
-ENTRYPOINT /opt/mssql/bin/sqlservr
-# CMD exec /bin/bash -c "trap : TERM INT; sleep infinity & wait"
+# create a new database if env var is set
+ENTRYPOINT /opt/mssql/bin/sqlservr & /opt/mssql/bin/post-entrypoint.sh
 
 # label the container
 LABEL org.opencontainers.image.vendor="dbatools"

--- a/sqlinstance/docker-compose.yml
+++ b/sqlinstance/docker-compose.yml
@@ -7,8 +7,6 @@ services:
     container_name: mssql1
     hostname: mssql1
     image: dbatools/sqlinstance
-    environment:
-      - MSSQL_DB=mydb1
     build:
       context: .
       labels:
@@ -30,8 +28,6 @@ services:
     container_name: mssql2
     hostname: mssql2
     image: dbatools/sqlinstance2
-    environment:
-      - MSSQL_DB=mydb2
     build:
       context: .
       labels:

--- a/sqlinstance/docker-compose.yml
+++ b/sqlinstance/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     container_name: mssql1
     hostname: mssql1
     image: dbatools/sqlinstance
+    environment:
+      - MSSQL_DB=mydb1
     build:
       context: .
       labels:
@@ -28,6 +30,8 @@ services:
     container_name: mssql2
     hostname: mssql2
     image: dbatools/sqlinstance2
+    environment:
+      - MSSQL_DB=mydb2
     build:
       context: .
       labels:

--- a/sqlinstance/scripts/post-entrypoint.sh
+++ b/sqlinstance/scripts/post-entrypoint.sh
@@ -1,0 +1,23 @@
+# if an environment variable for newdb exists, create it
+if [ -n "${MSSQL_DB+1}" ]; then
+    # load up environment variables
+    export SQLCMDSERVER=localhost
+    export SQLCMDUSER=sqladmin
+    export SQLCMDPASSWORD=dbatools.IO
+    export PATH=$PATH:/opt/mssql-tools/bin
+
+    # wait for sql to be ready
+    for i in {1..30};
+    do
+        sqlcmd -S localhost -d master -Q "SELECT @@VERSION"
+        if [ $? -ne 0 ];then
+            sleep 2
+        fi
+    done
+
+    # create the db if it doesn't exist already
+    sqlcmd -S localhost -d master -Q "IF DB_ID (N'${MSSQL_DB}') IS NULL CREATE DATABASE ${MSSQL_DB};"
+fi
+
+# keep it going
+sleep infinity


### PR DESCRIPTION
This will help enable database creation at startup.

You can either add it into your compose file

```yaml
    container_name: mssql1
    hostname: mssql1
    image: dbatools/sqlinstance1
    environment:
      - MSSQL_DB=mydb1
    .......
    container_name: mssql2
    hostname: mssql2
    image: dbatools/sqlinstance2
    environment:
      - MSSQL_DB=mydb2
``` 
or at the command line

```
docker run -p 1433:1433  --volume shared:/shared:z --name mssql1 --hostname mssql1 --network localnet --env MSSQL_DB=mydb1 -d dbatools/sqlinstance
docker run -p 14333:1433  --volume shared:/shared:z --name mssql2 --hostname mssql2 --network localnet --env MSSQL_DB=mydb2 -d dbatools/sqlinstance2
```

![image](https://user-images.githubusercontent.com/8278033/190506983-91203a30-56a0-44dd-b8e3-a326a5857ea4.png)

To fill need for https://github.com/microsoft/mssql-docker/issues/2 and https://github.com/Microsoft/mssql-docker/issues/11. Hat tip 🤠  to https://github.com/twright-msft/mssql-node-docker-demo-app/blob/master/entrypoint.sh

So far this has not been tested on ARM/Edge.  Thanks for the 607,356 image pulls as of today! Who knew the empty sqlinstance2 would be twice as popular?